### PR TITLE
fix: docker.sock permission denied on Debian (kind cluster create)

### DIFF
--- a/tasks/install-docker.yaml
+++ b/tasks/install-docker.yaml
@@ -54,3 +54,5 @@
   ansible.builtin.copy:
     content: '{ "group": "dockerroot" }'
     dest: /etc/docker/daemon.json
+  when: ansible_os_family == "RedHat"
+  notify: Restart docker

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -23,6 +23,9 @@
   ansible.builtin.include_tasks: docker-users.yaml
   when: docker_users|length > 0
 
+- name: Reset SSH connection so docker group membership becomes effective
+  ansible.builtin.meta: reset_connection
+
 - name: Enable additional options
   ansible.builtin.include_tasks: enable-options.yaml
 


### PR DESCRIPTION
## Summary
- Gate the unconditional ` /etc/docker/daemon.json` write (`{"group":"dockerroot"}`) to `ansible_os_family == "RedHat"`. On Debian/Ubuntu the `dockerroot` group does not exist, so the daemon.json caused docker to fall back to root-only ownership of `/var/run/docker.sock`, making the `docker` group membership added by `docker-users.yaml` useless.
- Add a `notify: Restart docker` to that same task so daemon.json changes actually take effect.
- Add `meta: reset_connection` after `docker-users.yaml` so subsequent `become_user: "{{ ansible_user }}"` tasks pick up the freshly added `docker` group membership.

## Why
Observed in a Dapr-VM provisioning run (`stuttgart-things/stuttgart-things` PR #2097, run 24950454453, job 73059511895): `kind create cluster` failed with `permission denied while trying to connect to the docker API at unix:///var/run/docker.sock` on a Debian-family VM, even though the user was added to the `docker` group earlier in the play.

## Test plan
- [ ] Run molecule against a Debian/Ubuntu image — kind cluster comes up without docker.sock permission errors.
- [ ] Run molecule against a RedHat/CentOS image — `dockerroot` daemon.json still written, behavior unchanged.
- [ ] Re-run the failing Dapr-VM workflow after bumping the role version pin in `stuttgart-things/ansible` `collections/container/collection.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)