### PR TITLE
fix: rename trick for kind/yq bin_dir (basename != bin_name)

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -116,7 +116,10 @@ bin:
     source_url: "https://github.com/kubernetes-sigs/kind/releases/download/v{{ kind_version }}/kind-linux-amd64"
     bin_to_copy: kind-linux-amd64
     to_remove: ""
-    bin_dir: "/usr/bin"
+    # bin_to_copy basename (kind-linux-amd64) != bin_name (kind): the copy task
+    # appends the source basename to bin_dir, so bin_dir must be /usr/bin/kind
+    # to rename the artifact to `kind`. (/usr/bin alone -> /usr/bin/kind-linux-amd64)
+    bin_dir: "/usr/bin/kind"
     version_cmd: "version"
     target_version: "{{ kind_version }}"
   helmfile:
@@ -156,6 +159,8 @@ bin:
     source_url: "https://github.com/mikefarah/yq/releases/download/v{{ yq_version }}/yq_linux_amd64.tar.gz"
     bin_to_copy: yq_linux_amd64
     to_remove: ""
-    bin_dir: "/usr/bin"
+    # bin_to_copy basename (yq_linux_amd64) != bin_name (yq): bin_dir must be
+    # /usr/bin/yq so the copy task renames the artifact to `yq`.
+    bin_dir: "/usr/bin/yq"
     version_cmd: " version"
     target_version: "v{{ yq_version }}"

--- a/molecule/docker_test/converge.yml
+++ b/molecule/docker_test/converge.yml
@@ -43,7 +43,7 @@
         source_url: "https://github.com/kubernetes-sigs/kind/releases/download/v{{ kind_version }}/kind-linux-amd64"
         bin_to_copy: kind-linux-amd64
         to_remove: ""
-        bin_dir: "/usr/bin"
+        bin_dir: "/usr/bin/kind"
         version_cmd: "version"
         target_version: "{{ kind_version }}"
       helmfile:


### PR DESCRIPTION
The blanket `/usr/bin` fix in #35 broke kind and yq: their `bin_to_copy` basename (`kind-linux-amd64`, `yq_linux_amd64`) differs from `bin_name`, so the copy task lands the artifact under the wrong filename and the tool is 'not found' at the kind-config validation step (`yq: not found`). Restore the `/usr/bin/<name>` rename trick for these two while keeping helmfile/helm/k9s at `/usr/bin` (their basenames already match).

🤖 Generated with [Claude Code](https://claude.com/claude-code)