### PR TITLE
fix: kind default 0.32.0 + kubeconfig 0.0.0.0→127.0.0.1 for k8s 1.35

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -47,7 +47,7 @@ docker_users: [sthings]
 install_kind: true
 # To rebuild (delete and recreate) existing cluster
 rebuild_kind_cluster: true
-kind_version: 0.31.0
+kind_version: 0.32.0 # datasource=github-tags depName=kubernetes-sigs/kind
 kind_cluster_name: dev
 kubectl_version: 1.35.0
 kind_node_image_version: 1.35.0

--- a/tasks/kind.yaml
+++ b/tasks/kind.yaml
@@ -92,6 +92,19 @@
       ansible.builtin.debug:
         msg: "Cluster {{ kind_cluster_name }} {{ 'recreated' if (rebuild_kind_cluster | default(false) | bool) else 'already exists and was not modified' if (cluster_exists.rc == 0) else 'created' }}"
 
+    - name: Normalize kubeconfig server 0.0.0.0 -> 127.0.0.1 for local access
+      # kind writes `server: https://0.0.0.0:<port>` into the kubeconfig when the API
+      # port is published via extraPortMappings without an explicit apiServerAddress.
+      # The apiserver cert only covers 127.0.0.1, so a local kubectl against 0.0.0.0
+      # fails TLS verification. Rewrite it to the loopback the cert actually covers.
+      # No-op when the tasks above already set a routable address (no 0.0.0.0 to match).
+      ansible.builtin.replace:
+        path: "{{ kubeconfig_folder }}/{{ kind_cluster_name }}"
+        regexp: 'https://0\.0\.0\.0:'
+        replace: 'https://127.0.0.1:'
+      become: yes
+      become_user: "{{ ansible_user }}"
+
     - name: Verify kind cluster
       ansible.builtin.shell: |
         kind get clusters


### PR DESCRIPTION
Two fixes found while running the role end-to-end to bootstrap a **k8s 1.35** kind cluster on a fresh VM (part of the machinery-parity work in [stuttgart-things/ansible#988](https://github.com/stuttgart-things/ansible/issues/988) / [#989](https://github.com/stuttgart-things/ansible/pull/989)). Both were worked around live; this lands them at source.

### 1. `defaults/main.yaml`: default `kind_version` 0.31.0 → 0.32.0
kind `0.31.0` does not carry the `kindest/node:v1.35.0` image digest, so any consumer that relies on the role default (e.g. the `sthings.container` `kind_xplane_cluster` play, which does not override `kind_version`) hits a **digest mismatch** on k8s 1.35. `0.32.0` ships the correct v1.35 digests. Added the renovate `datasource=github-tags` annotation so future bumps are automated (matching `yq_version`).

### 2. `tasks/kind.yaml`: normalize kubeconfig `0.0.0.0` → `127.0.0.1`
When the API port is published via `extraPortMappings` **without** an explicit `apiServerAddress` (the default path — `api_server_address` unset, `update_kubeconfig_ip: false`), kind writes:

```yaml
server: https://0.0.0.0:<port>
```

into the kubeconfig. The apiserver cert only covers `127.0.0.1` (+ the node/service IPs), so the role's own **`Verify kind cluster`** task — and any local `kubectl` — fails:

```
tls: failed to verify certificate: x509: certificate is valid for
10.96.0.1, 172.18.0.3, 127.0.0.1, not 0.0.0.0
```

The two existing kubeconfig-rewrite tasks are both gated (`api_server_address is defined` / `update_kubeconfig_ip | bool`), so the default path is left broken. This adds an **idempotent** `ansible.builtin.replace` that runs unconditionally after create; it is a no-op once one of those tasks has already set a routable address (no `0.0.0.0` left to match).

### Note — the docker-group race is already fixed here
The third issue we hit live (`permission denied … docker.sock` on the first `kind create`, because the SSH session predates the docker-group add) is **already resolved** at HEAD by the `meta: reset_connection` after "Create docker user" (commit `0cadf1b`, tag `2026.06.25`). Our run only hit it because the target had the stale `2026.04.02-3` role installed. No change needed — reinstalling the collection (which already pins `2026.06.25`) picks it up.

### Verification
Both files parse (`yaml.safe_load`). Validated live: with these two changes plus the already-landed `reset_connection`, the full kind-1.35 + machinery bootstrap on a fresh VM runs `failed=0` (see ansible#988).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
