### PR TITLE
fix(yq): use `yq --version` for the version check

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -162,5 +162,8 @@ bin:
     # bin_to_copy basename (yq_linux_amd64) != bin_name (yq): bin_dir must be
     # /usr/bin/yq so the copy task renames the artifact to `yq`.
     bin_dir: "/usr/bin/yq"
-    version_cmd: " version"
+    # mikefarah yq v4 needs `yq --version` — `yq version` errors (lexer: invalid
+    # input text "version"), which made the version check permanently fail and
+    # reinstalled yq every run.
+    version_cmd: " --version"
     target_version: "v{{ yq_version }}"


### PR DESCRIPTION
mikefarah yq v4 rejects `yq version` (`Error: lexer: invalid input text "version"`), so `download-install-binary`'s version check compared `bin_version` against the error output and never matched → **yq was re-downloaded and re-copied on every run**.

Switches the yq `version_cmd` in `defaults/main.yaml` from ` version` to ` --version`.

Companion to the `install_path` crash fix (download-install-binary #49). Tracked in download-install-binary#50 (item 2b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)