### PR TITLE
fix(kind): take the API port from kind, not a fresh random value

### DIFF
--- a/tasks/kind.yaml
+++ b/tasks/kind.yaml
@@ -69,6 +69,36 @@
         (cluster_exists.rc != 0)
       register: cluster_create
 
+    # Re-export from kind rather than trusting whatever is on disk. On a re-run
+    # that did NOT recreate the cluster (rebuild_kind_cluster: false), the file
+    # may be missing entirely, and `api_server_port` above has just been rolled
+    # to a fresh random value that the running cluster is not listening on —
+    # writing that into the kubeconfig yields `connection refused`. kind is the
+    # only authority on the port the cluster actually bound.
+    - name: Export kubeconfig from kind
+      ansible.builtin.shell: |
+        kind export kubeconfig --name {{ kind_cluster_name }} --kubeconfig {{ kubeconfig_folder }}/{{ kind_cluster_name }}
+      become: yes
+      become_user: "{{ ansible_user }}"
+      changed_when: false
+
+    - name: Read the live API port from the exported kubeconfig
+      ansible.builtin.shell: |
+        set -o pipefail
+        yq '.clusters[0].cluster.server' {{ kubeconfig_folder }}/{{ kind_cluster_name }} \
+          | sed -E 's#.*:([0-9]+)$#\1#'
+      args:
+        executable: /bin/bash
+      become: yes
+      become_user: "{{ ansible_user }}"
+      register: live_api_server_port
+      changed_when: false
+
+    - name: Use the live API port
+      ansible.builtin.set_fact:
+        api_server_port: "{{ live_api_server_port.stdout | trim }}"
+      when: live_api_server_port.stdout | default('') | trim | length > 0
+
     - name: Update kubeconfig with real API server address
       ansible.builtin.shell: |
         echo ""


### PR DESCRIPTION
## Problem

`api_server_port` is regenerated at random on every run:

```yaml
- name: Generate random port for API server
  set_fact:
    api_server_port: "{{ range(33000, 36001) | random }}"
  when: api_server_port is not defined and generate_api_server_port|default(true)|bool
```

On a re-run where the cluster already exists and `rebuild_kind_cluster` is `false`, the cluster is **not** recreated — but the kubeconfig was still rewritten with the new random port, which nothing is listening on:

```
The connection to the server 10.31.103.22:35044 was refused - did you specify the right host or port?
```

(the cluster was actually bound to `:33448`)

Two consequences: the play fails its own `Verify kind cluster` step on every second run, and it leaves behind a kubeconfig that cannot reach the cluster it describes.

## Fix

Export the kubeconfig from kind first, read the port back out of it, and use that for the rewrite. kind is the only authority on the port the cluster actually bound. The export also covers the case where the kubeconfig file is missing on a re-run that did not recreate the cluster — nothing else recreates it.

## Verification

On a LabUL VM running a `kind-test1` cluster created by an earlier run:

```
exported server: https://0.0.0.0:33448
parsed port: 33448
host ip: 10.31.103.22
rewritten: https://10.31.103.22:33448
NAME                       STATUS   ROLES           AGE   VERSION
kind-test1-control-plane   Ready    control-plane   42m   v1.35.0
kind-test1-worker          Ready    <none>          42m   v1.35.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXVxNQhoVf9HARnDRfPTbo